### PR TITLE
Add policy support for macro variable ranges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Features:
 * [X] Allow an arbitrary number of network clients to connect to an arbitrary number of controls.
 * [X] Parse, validate, and proxy individual MDC messages.
 * [X] Restrict access and allowable MDC commands by IP address range.
-* [ ] Allow / deny writes to certain macro variable ranges (e.g. WIPS calibration data).
+* [X] Allow writes only to certain macro variable ranges (e.g. protect the WIPS calibration data).
 * [ ] Audit logging
 
 MDC protocol enhancements:
@@ -60,9 +60,7 @@ configuration file or on a per-target basis.
 {
   "bind": "127.0.0.1",
   "policy": {
-    "127.0.0.1/32": {
-      "allow_unsafe": false
-    }
+    "10.0.0.0/8": {}
   },
   "targets": {
     "minimill.cnc.llc:5501": {
@@ -71,8 +69,12 @@ configuration file or on a per-target basis.
     "umc750.cnc.llc:5501": {
       "proxy_port": 5052,
       "policy": {
-        "10.1.0.0/16": {
-          "allow_unsafe": true
+        "10.1.2.0/24": {
+          "allow_writes": [
+            [1, 33],
+            [10200, 10299],
+            [10800, 10999]
+          ]
         }
       }
     }
@@ -80,7 +82,11 @@ configuration file or on a per-target basis.
 }
 ```
 
-The above configuration would proxy the MDC service on two different NGC controls to ports `5051` and `5052`.
+The above configuration would proxy the MDC service on two different NGC
+controls to ports `5051` and `5052`. The `10.0.0.0/8` netblock is allowed to
+connect to the proxy, may issue documented `?Q` commands, and may read any macro
+variables. Further down, the `10.2.2.0/24` netblock is allowed to write to a
+limited range of macro variables.
 
 ## Dummy server
 

--- a/mdcmux.json
+++ b/mdcmux.json
@@ -1,9 +1,7 @@
 {
   "bind": "127.0.0.1",
   "policy": {
-    "127.0.0.1/32": {
-      "allow_unsafe": false
-    }
+    "10.0.0.0/8": {}
   },
   "targets": {
     "minimill.cnc.llc:5501": {
@@ -12,8 +10,12 @@
     "umc750.cnc.llc:5501": {
       "proxy_port": 5052,
       "policy": {
-        "10.1.0.0/16": {
-          "allow_unsafe": true
+        "10.1.2.0/24": {
+          "allow_writes": [
+            [1, 33],
+            [10200, 10299],
+            [10800, 10999]
+          ]
         }
       }
     }

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 Bob Vawter (bob@vawter.org)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package proxy
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Validate the sample configuration parses correctly.
+func TestDemoConfig(t *testing.T) {
+	r := require.New(t)
+
+	f, err := os.Open("../mdcmux.json")
+	r.NoError(err)
+	defer func() { _ = f.Close() }()
+
+	var cfg Config
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
+	r.NoError(dec.Decode(&cfg))
+}


### PR DESCRIPTION
The policy may now define ranges of macro variables that a client may write to. This will help to protect, for example, the WIPS calibration data from an errant network client.