### PR TITLE
Improve wire format fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ Binaries are available from the [GitHub Releases](https://github.com/bobvawter/m
 Installation from source:
 
 ```sh
-go install vawter.tech/mdcmux
+go install vawter.tech/mdcmux@latest
+```
+
+Preflight build:
+
+```shell
+go tool github.com/goreleaser/goreleaser/v2 build --clean --snapshot
 ```
 
 ## Proxy use
@@ -102,18 +108,18 @@ mdcmux dummy --bind 127.0.0.1:13013 &
 
 # You can use PuTTY, etc.
 nc 127.0.0.1 13013
-?Q102
->>MODEL, MDCMUX
-?Q101
->>SOFTWARE VERSION, 100.24.000.1024
-?Q100
->>SERIAL NUMBER, 1024
-?Q600 10900
->>MACRO, 0.0
-?E10900 123.456
->>!
-?Q600 10900
->>MACRO, 123.456
+>?Q102
+>MODEL, MDCMUX
+>?Q101
+>SOFTWARE VERSION, 100.24.000.1024
+>?Q100
+>SERIAL NUMBER, 1024
+>?Q600 10900
+>MACRO, 0.0
+>?E10900 123.456
+>!
+>?Q600 10900
+>MACRO, 123.456
 ```
 
 ## Disclaimer

--- a/message/message.go
+++ b/message/message.go
@@ -23,6 +23,7 @@
 package message
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -33,6 +34,42 @@ import (
 	"strconv"
 	"strings"
 )
+
+const (
+	// EOL is a CRLF.
+	EOL = "\r\n"
+	// A Prompt is emitted on each line of output.
+	Prompt = '>'
+)
+
+// WriteFlusher is implemented by [bufio.Writer], for example.
+type WriteFlusher interface {
+	io.Writer
+	Flush() error
+}
+
+// WritePrompt writes a prompt to the output and then flushes it.
+func WritePrompt(w WriteFlusher) error {
+	if _, err := w.Write([]byte{Prompt}); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// WriteResponse writes a complete response message line to the output, followed
+// by a new prompt, and flushes.
+func WriteResponse(w WriteFlusher, format string, args ...any) error {
+	if _, err := w.Write([]byte{Prompt}); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, format, args...); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(EOL)); err != nil {
+		return err
+	}
+	return WritePrompt(w)
+}
 
 var (
 	numberFormat = regexp.MustCompile(`^\s*(?P<whole>[+-]?\d+)(?:\.(?P<frac>\d*))?\s*$`)
@@ -73,6 +110,22 @@ var documentedCommands = map[Number]struct{}{
 	CommandPartsCounter2:     {},
 	CommandThreeInOne:        {},
 	CommandMacroVariable:     {},
+}
+
+// ScanPrompt is a [bufio.ScanFunc] that reads each line of text and strips any
+// [Prompt] prefix characters.
+func ScanPrompt(data []byte, atEOF bool) (int, []byte, error) {
+	advance, token, err := bufio.ScanLines(data, atEOF)
+	if err != nil {
+		return 0, nil, err
+	}
+	for idx := range token {
+		if token[idx] != Prompt {
+			token = token[idx:]
+			break
+		}
+	}
+	return advance, token, nil
 }
 
 // A Number represents a fixed-point decimal value.
@@ -202,8 +255,8 @@ var (
 
 // Parse the input as a [Message].
 func Parse(bytes []byte) (Message, error) {
-	if len(bytes) == 0 {
-		return nil, errors.New("empty message")
+	if len(bytes) < 3 {
+		return nil, errors.New("undersized message")
 	}
 	if bytes[0] != '?' {
 		return nil, errors.New("invalid message: no leading '?'")
@@ -315,7 +368,7 @@ func Query(n Number) Message {
 }
 
 func (q *query) Command() (Number, bool)  { return CommandMacroVariable, true }
-func (q *query) IsSafe() bool             { return q.variable.whole >= 1 && q.variable.frac == 0 }
+func (q *query) IsSafe() bool             { return q.variable.whole >= 0 && q.variable.frac == 0 }
 func (q *query) Variable() (Number, bool) { return q.variable, true }
 
 func (q *query) LogValue() slog.Value {

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -42,7 +42,7 @@ func TestDecoration(t *testing.T) {
 		{M: Basic(CommandMachineSN), Command: true, Safe: true},
 		{M: Basic(Int64(999)), Command: true}, // Not safe because it's not documented.
 
-		{M: Response([]byte(">>!"))},
+		{M: Response([]byte(">!"))},
 
 		{M: Query(Int64(999)), Command: true, Safe: true, Variable: true},
 		{M: Query(NewNumber(999, 999)), Command: true, Variable: true}, // Not safe because of fractional number.
@@ -105,11 +105,11 @@ func TestParseMessage(t *testing.T) {
 		Err string
 		C   string // Canonical representation
 	}{
-		{S: "", Err: "empty message"},
+		{S: "", Err: "undersized message"},
 		{S: "Q100", Err: "no leading '?'"},
 		{S: "?U1", Err: "invalid character"},
 
-		{S: "?Q", Err: "expecting"},
+		{S: "?Q", Err: "undersized message"},
 		{S: "?Q100", M: Basic(Int64(100))},
 		{S: "?Q100  ", M: Basic(Int64(100)), C: "?Q100"},
 		{S: "?Q100.1", Err: "expecting"},
@@ -120,7 +120,7 @@ func TestParseMessage(t *testing.T) {
 		{S: "?Q600 1234.", M: Query(Int64(1234)), C: "?Q600 1234.0"},
 		{S: "?Q600 1234.567", M: Query(NewNumber(1234, 567))},
 
-		{S: "?E", Err: "expecting a variable number"},
+		{S: "?E", Err: "undersized message"},
 		{S: "?E1", Err: "expecting a variable number"},
 		{S: "?E1X", Err: "expecting a variable number"},
 		{S: "?E1 Y", Err: "expecting a variable number"},


### PR DESCRIPTION
This change improves how and when prompt characters are output. Writing of response lines is moved into two utility functions.

The dummy server responds to reads for macro variable 0 with NaN.